### PR TITLE
Black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+        files: ^projects/EarthNow/

--- a/projects/EarthNow/README.md
+++ b/projects/EarthNow/README.md
@@ -34,12 +34,15 @@ or running 'uv run' before python calls:
 `uv run python plotall.py --product basemap [other args]`
 
 ### Pre-commit hooks 
-Optional to the EarthNow workflow is a pre-commit hook to run the black formatter automatically before each git commit. If you wish to activate this, simply install the hook with
+Optional to the EarthNow workflow is a pre-commit hook to run the black formatter. 
+If you wish to activate this, simply install the hook with
 `pre-commit install`
 
 More details: 
-    - This commit hook is defined with `.pre-commit-config.yaml` in the root directory of the git repo.
-    - Commits will fail automatically it black reformats any files, and you will need to run `git commit` again to confirm  your changes.
+    - This commit hook is defined with `.pre-commit-config.yaml` in the root 
+      directory of the git repo.
+    - Commits will fail automatically it black reformats any files, and you will 
+      need to run `git commit` again to confirm the changes.
 
 
 

--- a/projects/EarthNow/README.md
+++ b/projects/EarthNow/README.md
@@ -12,27 +12,34 @@ You'll need uv installed to build the environment
 
 ### Installation
 In the root dir for EarthNow, run
-uv venv
+`uv venv`
 
 If .venv/ already exists, it won’t destroy it.
 
 Activate it:
 
-source .venv/bin/activate
+`source .venv/bin/activate`
 
 Install the env:
 
-uv pip install -e ".[plotting,images,dev]"
+`uv pip install -e ".[plotting,images,dev]"`
 
 (sorry for the optional list, I'm testing out how to handle the package)
 
 ### Environment
 After installation, you can activate/use the environment by either sourcing it
-source .env/bin/activate
+`source .env/bin/activate`
 
 or running 'uv run' before python calls:
-uv run python plotall.py --product basemap [other args]
+`uv run python plotall.py --product basemap [other args]`
 
+### Pre-commit hooks 
+Optional to the EarthNow workflow is a pre-commit hook to run the black formatter automatically before each git commit. If you wish to activate this, simply install the hook with
+`pre-commit install`
+
+More details: 
+    - This commit hook is defined with `.pre-commit-config.yaml` in the root directory of the git repo.
+    - Commits will fail automatically it black reformats any files, and you will need to run `git commit` again to confirm  your changes.
 
 
 

--- a/projects/EarthNow/pyproject.toml
+++ b/projects/EarthNow/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
   "mypy>=1.7",
   "ipykernel>=7.2.0",
   "xarray>=2026.2.0",
+  "pre-commit>=4.5.1",
 ]
 
 # uv_build file selection (recommended for flat layout repos)

--- a/projects/EarthNow/src/earthnow/products/product_assignments.md
+++ b/projects/EarthNow/src/earthnow/products/product_assignments.md
@@ -57,7 +57,7 @@ Convective Available Potential Energy
 
 `ploteic_helicity`
 2-5km Helicity and Radar Reflectivity
-- Assignee:
+- Assignee: Hannah
 - Status:
 
 

--- a/projects/EarthNow/src/earthnow/products/product_assignments.md
+++ b/projects/EarthNow/src/earthnow/products/product_assignments.md
@@ -48,7 +48,7 @@ Near Surface Winds
 `ploteic_t2m`
 2-meter Temperature
 - Assignee: Sandra
-- Status:
+- Status: Done!
 
 `ploteic_cape`
 Convective Available Potential Energy
@@ -57,7 +57,7 @@ Convective Available Potential Energy
 
 `ploteic_helicity`
 2-5km Helicity and Radar Reflectivity
-- Assignee: Hannah
+- Assignee:
 - Status:
 
 
@@ -76,8 +76,8 @@ Carbon Aerosol Optical Thickness
 ## Global Dynamics
 `ploteic_vort500`
 500-mb Vorticity and Heights
-- Assignee: Hannah
-- Status:
+- Assignee:Hannah
+- Status: Done! Except for locating the identical basemap that the IDL code uses.
 
 `ploteic_wind250`
 250-mb Wind Speed and MSLP


### PR DESCRIPTION
Currently applied only to files under the projects/EarthNow directory. Automatically runs black to reformat where necessary, whenever you do a `git commit`. 