### PR TITLE
Basemap imagery fix

### DIFF
--- a/projects/EarthNow/src/earthnow/wxmaps_base_images.py
+++ b/projects/EarthNow/src/earthnow/wxmaps_base_images.py
@@ -168,6 +168,8 @@ class BaseImageCache:
             print(
                 f"  Original size: {orig_width}x{orig_height} ({orig_pixels:.1f}M pixels)"
             )
+            # Convert to RBGA if in greyscale luminance alpha
+            img = img.convert("RGBA")
 
             # Only downsample if image is larger than target
             if orig_width > target_width:
@@ -192,6 +194,7 @@ class BaseImageCache:
 
         # Cache it
         cls._cache[cache_key] = img_array
+        logger.info(f"Image converted: {img_array.shape}")
 
         return img_array
 
@@ -344,13 +347,6 @@ class BaseImagePlotter:
         # Automatic limb darkening for full disk GEO
         if isinstance(ax.projection, ccrs.Geostationary):
             warped_img = BaseImagePlotter.apply_limb_darkening(warped_img)
-
-        # Fix for greyscale imagery
-        if warped_img.ndim == 3 and warped_img.shape[2] == 2:
-            rgb_array = warped_img[:, :, 0]
-            a_array = warped_img[:, :, 1]
-            warped_img = np.dstack((rgb_array, rgb_array, rgb_array, a_array))
-        logger.info("Img dimension fixed: {warped_img.shape}")
 
         # Plot the transformed image
         # The warped_img array is constructed with row 0 = bottom (target_extent[2])

--- a/projects/EarthNow/src/earthnow/wxmaps_base_images.py
+++ b/projects/EarthNow/src/earthnow/wxmaps_base_images.py
@@ -16,6 +16,7 @@ from enum import Enum
 class BaseImageType(Enum):
     """Predefined base image types"""
 
+    NATURAL_EARTH_GREY = "natural_earth_grey"
     NATURAL_EARTH_GREYBLUE = "natural_earth_greyblue"
     NATURAL_EARTH_LIGHT = "natural_earth_light"
     GEOCOLOR_LIGHT = "geocolor_light"
@@ -32,6 +33,12 @@ class BaseImageConfig:
 
     # Predefined image paths
     IMAGES = {
+        "natural_earth_grey": {
+            "path": "natural_earth_grey_noice_16200x8100.jpg",
+            "extent": [-180, 180, -90, 90],
+            "description": "Natural Earth Greyscale Blue (no arctic ice)",
+            "projection": "platecarree",
+        },
         "natural_earth_greyblue": {
             "path": "natural_earth_greyblue_noice_16200x8100.jpg",
             "extent": [-180, 180, -90, 90],

--- a/projects/EarthNow/src/earthnow/wxmaps_base_images.py
+++ b/projects/EarthNow/src/earthnow/wxmaps_base_images.py
@@ -12,6 +12,10 @@ from pathlib import Path
 from typing import Optional, Tuple
 from enum import Enum
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class BaseImageType(Enum):
     """Predefined base image types"""
@@ -335,10 +339,18 @@ class BaseImagePlotter:
             fill_value=0,
             flip_source_y=True,  # Flip source from origin='upper' to origin='lower' before interpolation
         )
+        logger.info(f"Image dims: {warped_img.shape}")
 
         # Automatic limb darkening for full disk GEO
         if isinstance(ax.projection, ccrs.Geostationary):
             warped_img = BaseImagePlotter.apply_limb_darkening(warped_img)
+
+        # Fix for greyscale imagery
+        if warped_img.ndim == 3 and warped_img.shape[2] == 2:
+            rgb_array = warped_img[:, :, 0]
+            a_array = warped_img[:, :, 1]
+            warped_img = np.dstack((rgb_array, rgb_array, rgb_array, a_array))
+        logger.info("Img dimension fixed: {warped_img.shape}")
 
         # Plot the transformed image
         # The warped_img array is constructed with row 0 = bottom (target_extent[2])

--- a/projects/EarthNow/src/earthnow/wxmaps_config.py
+++ b/projects/EarthNow/src/earthnow/wxmaps_config.py
@@ -300,17 +300,11 @@ class StyleConfig:
     def grey_topo() -> "StyleConfig":
         """Testing to create grey topo style"""
         return StyleConfig(
-            # Currently don't have the correct grey_topo base image
-            # so testing using only shapes
-            # Eventually we can put the base image here
-            # use_base_image=True,
-            # base_image_type="natural_earth_greyblue",
-            background_color="white",
-            text_color="black",
+            use_base_image=True,
+            base_image_type="custom",
             use_gshhs=False,
-            ocean_color="#E6E6E6",
-            land_color="#FFFFFF",
-            show_timestamp=True,  # Defaults to False now, add it in your style for testing
+            ocean_color="#E6E6E6",  # Ok actually the config of the basemap is just that if the image is called, then none of the cartopy or other shapefile features plot
+            show_timestamp=True,  # Defaults is False now, add it in your style for testing
         )
 
     @staticmethod
@@ -322,6 +316,7 @@ class StyleConfig:
             base_image_type="natural_earth_greyblue",
             use_gshhs=False,
         )
+
 
 
 @dataclass

--- a/projects/EarthNow/src/earthnow/wxmaps_config.py
+++ b/projects/EarthNow/src/earthnow/wxmaps_config.py
@@ -310,6 +310,7 @@ class StyleConfig:
             use_gshhs=False,
             ocean_color="#E6E6E6",
             land_color="#FFFFFF",
+            show_timestamp=True,  # Defaults to False now, add it in your style for testing
         )
 
     @staticmethod

--- a/projects/EarthNow/src/earthnow/wxmaps_config.py
+++ b/projects/EarthNow/src/earthnow/wxmaps_config.py
@@ -301,9 +301,9 @@ class StyleConfig:
         """Testing to create grey topo style"""
         return StyleConfig(
             use_base_image=True,
-            base_image_type="custom",
+            base_image_path="/discover/nobackup/jardizzo/maps/basemaps/shadedrelief_grayscale.21600x10800.png",  # Specify this line for custom imagery
             use_gshhs=False,
-            ocean_color="#E6E6E6",  # Ok actually the config of the basemap is just that if the image is called, then none of the cartopy or other shapefile features plot
+            # ocean_color="#E6E6E6",  # Ok actually the config of the basemap is just that if the image is called, then none of the cartopy or other shapefile features plot
             show_timestamp=True,  # Defaults is False now, add it in your style for testing
         )
 
@@ -316,7 +316,6 @@ class StyleConfig:
             base_image_type="natural_earth_greyblue",
             use_gshhs=False,
         )
-
 
 
 @dataclass


### PR DESCRIPTION
- Basemap imagery: we can call `base_img_path` in the current style config and then use our own basemap image. Added functionality for greyscale basemap imagery fix
~~- edited the uv dev env, moved it to the group that will auto sync in uv run (don't need to specify uv run --dev)~~
~~-a bunch of fixes around the multiprocessing Pool function used in the original scripts. Since we are likely going to implement CYCL to run singular "pdate" runs, is this functionality even useful anymore? It doesn't make sense to "Pool" over dates if there is only one date...~~ Moved strikethrough to #95 