### PR TITLE
Jardizzo

### DIFF
--- a/projects/EarthNow/src/earthnow/data_readers/__init__.py
+++ b/projects/EarthNow/src/earthnow/data_readers/__init__.py
@@ -8,5 +8,10 @@ from .registry import DATA_READERS
 from . import geos_cycled_replays
 from . import geos_forward_processing
 from . import gencast_geos_fp
+from . import conus2kmfc
+from . import conus2kmrp
+from . import conus2kmfc_lcc
+from . import conus2kmrp_lcc
+from . import merra2
 
 __all__ = ["DATA_READERS"]

--- a/projects/EarthNow/src/earthnow/data_readers/conus2kmfc.py
+++ b/projects/EarthNow/src/earthnow/data_readers/conus2kmfc.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+from .dataservice import DataService
+from .registry import register
+
+CONUS2KMFC_URI = "/discover/nobackup/projects/gmao/osse2/HWT/CONUS02KM/Feature-c2160_L137/forecasts/CYCLED_REPLAY_P10800_C21600_T21600_%%Y%%m%%d_%%Hz/GEOS.$collection.%Y%m%d_%H%Mz.nc4"
+
+CONUS2KMFC_VARS = dict(
+    VORT500="VORT500.inst1_2d_asm_Nx",
+    H500="H500.inst1_2d_asm_Nx",
+    T2M="T2M.inst1_2d_asm_Nx",
+)
+
+CONUS2KMFC = SimpleNamespace(
+    uri=CONUS2KMFC_URI,
+    description="GEOS_based_on_Feature-c2160_L137",
+    type="forecast",
+    title="CONUS 2KM Forecast",
+    grid="latlon",
+    vars=CONUS2KMFC_VARS,
+)
+
+
+@register("CONUS2KMFC")
+class conus2kmfc(DataService):
+    def __init__(self, **kwargs):
+        super().__init__(CONUS2KMFC)

--- a/projects/EarthNow/src/earthnow/data_readers/conus2kmfc_lcc.py
+++ b/projects/EarthNow/src/earthnow/data_readers/conus2kmfc_lcc.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+from .dataservice import DataService
+from .registry import register
+
+CONUS2KMFC_LCC_URI = "/discover/nobackup/projects/gmao/osse2/HWT/CONUS02KM/Feature-c2160_L137/forecasts/CYCLED_REPLAY_P10800_C21600_T21600_%%Y%%m%%d_%%Hz/GEOS.$collection.%Y%m%d_%H%Mz.nc4"
+
+CONUS2KMFC_LCC_COORDS = (
+    "/discover/nobackup/projects/gmao/osse2/stage/BCS_FILES/lambert_grid.nc4"
+)
+
+CONUS2KMFC_LCC_VARS = dict(
+    VORT500="VORT500.hwt_15mn_slv_LCC",
+    H500="H500.hwt_15mn_slv_LCC",
+    TMP_2M="TMP_2M.hwt_15mn_slv_LCC",
+)
+
+CONUS2KMFC_LCC = SimpleNamespace(
+    uri=CONUS2KMFC_LCC_URI,
+    description="GEOS_based_on_Feature-c2160_L137",
+    type="forecast",
+    title="CONUS 2KM Forecast",
+    grid="lcc",
+    vars=CONUS2KMFC_LCC_VARS,
+    coords=CONUS2KMFC_LCC_COORDS,
+)
+
+
+@register("CONUS2KMFC_LCC")
+class conus2kmfc_lcc(DataService):
+    def __init__(self, **kwargs):
+        super().__init__(CONUS2KMFC_LCC)

--- a/projects/EarthNow/src/earthnow/data_readers/conus2kmrp.py
+++ b/projects/EarthNow/src/earthnow/data_readers/conus2kmrp.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+from .dataservice import DataService
+from .registry import register
+
+CONUS2KMRP_URI = "/discover/nobackup/projects/gmao/osse2/HWT/CONUS02KM/Feature-c2160_L137/holding/$collection/%Y%m/Feature-c2160_L137.$collection.%Y%m%d_%H%Mz.nc4"
+
+CONUS2KMRP_VARS = dict(
+    VORT500="VORT500.inst1_2d_asm_Nx",
+    H500="H500.inst1_2d_asm_Nx",
+    T2M="T2M.inst1_2d_asm_Nx",
+)
+
+CONUS2KMRP = SimpleNamespace(
+    uri=CONUS2KMRP_URI,
+    description="CONUS02km_137L_replay_to_GEOS-FP",
+    type="analysis",
+    title="CONUS 2KM Replay",
+    grid="latlon",
+    vars=CONUS2KMRP_VARS,
+)
+
+
+@register("CONUS2KMRP")
+class conus2kmrp(DataService):
+    def __init__(self, **kwargs):
+        super().__init__(CONUS2KMRP)

--- a/projects/EarthNow/src/earthnow/data_readers/conus2kmrp_lcc.py
+++ b/projects/EarthNow/src/earthnow/data_readers/conus2kmrp_lcc.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+from .dataservice import DataService
+from .registry import register
+
+CONUS2KMRP_LCC_URI = "/discover/nobackup/projects/gmao/osse2/HWT/CONUS02KM/Feature-c2160_L137/holding/$collection/%Y%m/Feature-c2160_L137.$collection.%Y%m%d_%H%Mz.nc4"
+
+CONUS2KMRP_LCC_COORDS = (
+    "/discover/nobackup/projects/gmao/osse2/stage/BCS_FILES/lambert_grid.nc4"
+)
+
+CONUS2KMRP_LCC_VARS = dict(
+    VORT500="VORT500.hwt_30mn_slv_LCC",
+    H500="H500.hwt_30mn_slv_LCC",
+    T2M="T2M.hwt_30mn_slv_LCC",
+)
+
+CONUS2KMRP_LCC = SimpleNamespace(
+    uri=CONUS2KMRP_LCC_URI,
+    description="CONUS02km_137L_replay_to_GEOS-FP",
+    type="analysis",
+    title="CONUS 2KM Replay",
+    grid="lcc",
+    vars=CONUS2KMRP_LCC_VARS,
+    coords=CONUS2KMRP_LCC_COORDS,
+)
+
+
+@register("CONUS2KMRP_LCC")
+class conus2kmrp_lcc(DataService):
+    def __init__(self, **kwargs):
+        super().__init__(CONUS2KMRP_LCC)

--- a/projects/EarthNow/src/earthnow/data_readers/dataservice.py
+++ b/projects/EarthNow/src/earthnow/data_readers/dataservice.py
@@ -32,7 +32,7 @@ class SimpleNetCDFDataService(object):
 
     def get_coords(self):
 
-        if self.stream.grid != 'lcc':
+        if self.stream.grid != "lcc":
             lats = self.nc.variables["lat"][:]
             lons = self.nc.variables["lon"][:]
             return lats, lons
@@ -79,9 +79,8 @@ class SimpleNetCDFDataService(object):
 
             return data, lats, lons, metadata
 
-
     def resolve_file(self, fdate, pdate, **kwargs):
-        return 'none', 'none', 'none'
+        return "none", "none", "none"
 
 
 DataService = SimpleNetCDFDataService

--- a/projects/EarthNow/src/earthnow/data_readers/dataservice.py
+++ b/projects/EarthNow/src/earthnow/data_readers/dataservice.py
@@ -1,0 +1,87 @@
+import os
+import datetime as dt
+from netCDF4 import Dataset
+
+
+class SimpleNetCDFDataService(object):
+
+    def __init__(self, stream):
+
+        self.nc = None
+        self.filename = ""
+        self.stream = stream
+
+    def open(self, collection, pdate, fdate=None):
+
+        time_dt = dt.datetime.strptime(pdate, "%Y%m%d_%Hz")
+        fname = time_dt.strftime(self.stream.uri)
+
+        if fdate:
+            fcst_dt = dt.datetime.strptime(fdate, "%Y%m%d_%Hz")
+            fname = fcst_dt.strftime(fname)
+
+        fname = fname.replace("$collection", collection)
+
+        if fname == self.filename:
+            return fname
+
+        self.nc = Dataset(fname)
+        self.filename = fname
+
+        return fname
+
+    def get_coords(self):
+
+        if self.stream.grid != 'lcc':
+            lats = self.nc.variables["lat"][:]
+            lons = self.nc.variables["lon"][:]
+            return lats, lons
+        else:
+            with Dataset(self.stream.coords) as nc:
+                return nc.variables["lats"][:], nc.variables["lons"][:]
+
+    def get_var(self, varname, level=None):
+        var = self.nc.variables[varname]
+        return var
+
+    def read_variable(self, fdate, pdate, variables):
+
+        if isinstance(variables, str):
+            variables = [variables]
+
+        for name in variables:
+
+            if name not in self.stream.vars:
+                continue
+
+            expr = self.stream.vars[name]
+            varname, collection = expr.split(".")
+            filename = self.open(collection, pdate, fdate)
+
+            var = self.get_var(varname)
+            lats, lons = self.get_coords()
+
+            metadata = {
+                "units": getattr(var, "units", ""),
+                "long_name": getattr(var, "long_name", varname),
+                "collection": collection,
+                "grid": self.stream.grid,
+                "file": os.path.basename(filename),
+            }
+
+            print(f"Using file      : {filename}")
+            print(f"Using collection: {collection}")
+            print(f"Using variable  : {varname}")
+
+            data = var[:]
+            if data.ndim >= 3:
+                data = data[0]
+
+            return data, lats, lons, metadata
+
+
+    def resolve_file(self, fdate, pdate, **kwargs):
+        return 'none', 'none', 'none'
+
+
+DataService = SimpleNetCDFDataService

--- a/projects/EarthNow/src/earthnow/data_readers/merra2.py
+++ b/projects/EarthNow/src/earthnow/data_readers/merra2.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+from .dataservice import DataService
+from .registry import register
+
+MERRA2_URI = "/discover/nobackup/projects/gmao/merra2/data/pub/products/MERRA2_all/Y%Y/M%m/MERRA2.inst1_2d_asm_Nx.%Y%m%d.nc4"
+
+MERRA2_VARS = dict(
+    VORT500="none",
+    H500="H500.tavg1_2d_slv_Nx",
+    T2M="T2M.inst1_2d_asm_Nx",
+)
+
+MERRA2 = SimpleNamespace(
+    uri=MERRA2_URI,
+    description="MERRA2 Analysis",
+    type="analysis",
+    title="MERRA2 Analysis",
+    grid="latlon",
+    vars=MERRA2_VARS,
+)
+
+
+@register("MERRA2")
+class merra2(DataService):
+    def __init__(self, **kwargs):
+        super().__init__(MERRA2)

--- a/projects/WxVis/src/wxv/basemaps/basemap.py
+++ b/projects/WxVis/src/wxv/basemaps/basemap.py
@@ -1,0 +1,37 @@
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+
+import cartopy
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+
+xsize=10800
+ysize=5400
+name = 'shadedrelief_grayscale.10800x5400.png'
+extent=[-180, 180, -90, 90]
+
+fig = plt.figure(figsize=(xsize*2/300.0, ysize*2/300.0), dpi=100,facecolor=(1,1,1,0))
+
+# 1. Setup projection and extent
+proj = ccrs.PlateCarree()
+ax = plt.axes(projection=proj)
+ax.set_extent(extent, crs=ccrs.PlateCarree())
+
+# 2. Load and plot custom image
+img = plt.imread(name)
+ax.imshow(img, origin='upper', extent=extent, transform=ccrs.PlateCarree())
+
+#ax.coastlines(resolution='50m', color='white')
+
+mapProj=ccrs.PlateCarree(central_longitude=np.mean(extent[:2]))
+map=fig.add_subplot(1,1,1,projection=mapProj)
+map.set_extent(extent, crs=ccrs.PlateCarree())
+map.axis('off')
+
+#map.add_feature(cfeature.LAND, zorder=100, facecolor='red')
+map.add_feature(cfeature.OCEAN, zorder=100, facecolor=(0.85,0.85,0.85))
+map.add_feature(cfeature.LAKES,facecolor=(0.85,0.85,0.85))
+
+plt.savefig('map.png', format='png', bbox_inches='tight', pad_inches=0,
+                        dpi=300, facecolor='black')

--- a/projects/WxVis/src/wxv/basemaps/bright.py
+++ b/projects/WxVis/src/wxv/basemaps/bright.py
@@ -1,0 +1,16 @@
+#! /usr/bin/env python
+
+import sys
+import os
+from PIL import Image, ImageOps
+
+from imutils import imbright
+
+Image.MAX_IMAGE_PIXELS = None
+
+fname = sys.argv[1]
+oname = sys.argv[2]
+
+img = Image.open(fname).convert("LA")
+img = imbright(img, 1.8)
+img.save(oname, format='png')

--- a/projects/WxVis/src/wxv/basemaps/esri.py
+++ b/projects/WxVis/src/wxv/basemaps/esri.py
@@ -1,0 +1,22 @@
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+from cartopy.io.img_tiles import GoogleTiles
+
+# Custom class for ESRI Shaded Relief
+class ShadedReliefESRI(GoogleTiles):
+    def _image_url(self, tile):
+        x, y, z = tile
+        url = ('https://server.arcgisonline.com/ArcGIS/rest/services/'
+               'World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}.jpg').format(
+            z=z, y=y, x=x)
+        return url
+
+# Setup Plot
+fig = plt.figure(figsize=(10, 8))
+ax = plt.axes(projection=ccrs.PlateCarree())
+
+# Add imagery with grayscale conversion
+ax.add_image(ShadedReliefESRI(), 8, cmap='gray')
+
+ax.set_extent([-10, 20, 30, 60])
+plt.show()

--- a/projects/WxVis/src/wxv/basemaps/imutils.py
+++ b/projects/WxVis/src/wxv/basemaps/imutils.py
@@ -1,0 +1,144 @@
+import PIL
+from PIL import Image, ImageChops, ImageEnhance, ImageDraw, ImageFont
+from PIL.ImageColor import getcolor, getrgb
+from PIL.ImageOps import grayscale, expand
+
+def immask(src, value):
+
+        data    = src.getdata()
+        mask    = self.mask.getdata()
+        img     = src.copy()
+        newData = []
+
+        for i in range(0,len(data)):
+            idata = data[i]
+            imask = mask[i]
+
+            if imask[0] == value:
+                newData.append(idata)
+            else:
+                newData.append((0,0,0,0))
+
+        img.putdata(newData)
+
+        return img
+
+#------------------------------------------------------------------------------
+
+def imfill(src, value, color):
+
+        if self.is_clear(color): return src
+
+        data    = src.getdata()
+        mask    = self.mask.getdata()
+        img     = src.copy()
+        newData = []
+        color   = tuple(color)
+
+        for i in range(0,len(data)):
+            idata = data[i]
+            imask = mask[i]
+
+            if imask[0] == value:
+                newData.append(color)
+            else:
+                newData.append(idata)
+
+        img.putdata(newData)
+
+        return img
+
+#------------------------------------------------------------------------------
+
+def imtint(src, tint_color):
+
+        if self.is_clear(tint_color): return src
+
+        tint_color  = '#%02x%02x%02x'%tuple(tint_color)
+        return self.image_tint(src, tint_color)
+
+#------------------------------------------------------------------------------
+
+def imbright(src, brightness):
+
+        if brightness == 1.0: return src
+
+        enhancer = ImageEnhance.Brightness(src)
+        return enhancer.enhance(brightness)
+
+#------------------------------------------------------------------------------
+
+def imsat(src, saturation):
+
+        if saturation == 1.0: return src
+
+        enhancer = ImageEnhance.Color(src)
+        return enhancer.enhance(saturation)
+
+#------------------------------------------------------------------------------
+
+def imcontrast(src, contrast):
+
+        if contrast == 1.0: return src
+
+        enhancer = ImageEnhance.Contrast(src)
+        return enhancer.enhance(contrast)
+
+#------------------------------------------------------------------------------
+
+def is_solid(color): 
+        if len(color) < 4: return True
+        if color[3] > 0.0: return True
+        return False
+
+#------------------------------------------------------------------------------
+
+def is_clear(color):
+        return not self.is_solid(color)
+
+#------------------------------------------------------------------------------
+
+def image_tint(src, tint='#ffffff'):
+
+        if isinstance(src,six.string_types):
+            src = Image.open(src)
+        if src.mode not in ['RGB', 'RGBA']:
+            raise TypeError('Unsupported source image mode: {}'.format(src.mode))
+        src.load()
+
+        tr, tg, tb = getrgb(tint)
+        tl = getcolor(tint, "L")  # tint color's overall luminosity
+        if not tl: tl = 1  # avoid division by zero
+        tl = float(tl)  # compute luminosity preserving tint factors
+        sr, sg, sb = map(lambda tv: tv/tl, (tr, tg, tb))  # per component
+                                                      # adjustments
+        # create look-up tables to map luminosity to adjusted tint
+        # (using floating-point math only to compute table)
+        luts = (tuple(map(lambda lr: int(lr*sr + 0.5), range(256))) +
+                tuple(map(lambda lg: int(lg*sg + 0.5), range(256))) +
+                tuple(map(lambda lb: int(lb*sb + 0.5), range(256))))
+        l = grayscale(src)  # 8-bit luminosity version of whole image
+        if sys.version_info.major==2: mode_len=Image.getmodebands(src.mode)
+        else: mode_len=len(src.getbands())
+        if mode_len < 4:
+            merge_args = (src.mode, (l, l, l))  # for RGB verion of grayscale
+        else:  # include copy of src image's alpha layer
+            a = Image.new("L", src.size)
+            a.putdata(src.getdata(3))
+            merge_args = (src.mode, (l, l, l, a))  # for RGBA verion of grayscale
+            luts += tuple(range(256))  # for 1:1 mapping of copied alpha values
+
+        return Image.merge(*merge_args).point(luts)
+
+#------------------------------------------------------------------------------
+
+def image_trim(im): 
+
+        bg = Image.new(im.mode, im.size, im.getpixel((0,0)))
+        diff = ImageChops.difference(im, bg)
+        diff = ImageChops.add(diff, diff, 2.0, -100)
+        bbox = diff.getbbox()
+        if bbox:
+            return im.crop(bbox)
+        return im
+

--- a/projects/WxVis/src/wxv/basemaps/panels.py
+++ b/projects/WxVis/src/wxv/basemaps/panels.py
@@ -1,0 +1,66 @@
+#! /usr/bin/env python
+"""
+    Reads NASA BlackMarble 500m regional tiles and assembles
+    a global image at the user-specified dimensions.
+
+    This application is very useful for creating BlackMarble basemaps
+    using the highest available resolution to yield the best quality.
+
+    Usage
+    -----
+    geometry : string
+        output image size in pixels (e.g. --geometry 2048x1024)
+        Note: best to use 2:1 aspect ratio for a global image.
+    grayscale: boolean
+        generates a grayscale BlackMarble image (e.g. --grayscale)
+
+    Dependencies
+    ------------
+    BlackMarble full resolution (500m) imagery obtained from:
+
+    https://earthobservatory.nasa.gov/features/NightLights/page3.php
+
+    Returns
+    -------
+    0: Success
+
+"""
+
+import sys
+import os
+from PIL import Image, ImageOps
+
+Image.MAX_IMAGE_PIXELS = None
+
+template = 'world.200406.3x21600x21600.%panel.jpg'
+panels = ['A','B','C','D']
+
+width = 21600 * 4
+height = 21600 * 2
+
+imout = Image.new('RGB', (width, height), color='black')
+
+for row in range(1,3):
+
+    for col in range(1,5):
+
+        id = panels[col-1] + str(row)
+        print(f'Pasting panel {id}')
+        fname = template.replace('%panel', id)
+        img = Image.open(fname).convert("RGBA")   
+
+        xp = (col-1) * 21600
+        yp = (row-1) * 21600
+
+        imout.paste(img, (xp, yp), img)
+        img.close()
+
+xsize = imout.width
+ysize = imout.height
+
+for factor in [4,8,16]:
+
+    width = round(xsize / factor)
+    height = round(ysize / factor)
+    im = imout.resize((width, height), Image.LANCZOS).convert('LA')
+    im.save(f'BlueMarble_NG_grayscale.{width}x{height}.png', format='png')


### PR DESCRIPTION
Added a SimpleNetCDF data service and associated readers as follows:

CONUS2KMFC - CONUS2KM Forecast
CONUS2KMFC_LCC - CONUS2KM Forecast (Lambert Conformal)
CONUS2KMRP - CONUS2KM Replay
CONUS2KMRP_LCC - CONUS2KM Replay (Lambert Conformal)
MERRA2 - MERRA2 Reanalysis (does not currently work for plots using pre-derived fields)

These data readers should be used with --exp-id and --exp-res to set output filenames. No other changes to codes were needed. The next step is to add an expression parser or alternate data services with expression parsers. 
