### PR TITLE
Modify boundaries argument and configuration

### DIFF
--- a/projects/EarthNow/bin/plot_one.sh
+++ b/projects/EarthNow/bin/plot_one.sh
@@ -17,6 +17,7 @@ usage() {
   echo "Optional arguments:"
   echo "  -p, --pdate: Frame time as YYYYMMDD_HHHHz (Required if Mode is 'single')"
   echo "  -l, --logger-opt: Logger option (e.g., DEBUG, INFO)"
+  echo "  -b, --boundaries: List of boundaries to plot"
   echo "  -h, --help: Display this help message"
   exit 1
 }
@@ -47,6 +48,15 @@ while [[ "$#" -gt 0 ]]; do
     -l|--logger-opt)
       LOGGER="$2"
       shift 2
+      ;;
+    -b|--boundaries)
+      BOUNDARIES_LIST=()
+      # Check if a list follows, then loop to grab everything until the next flag
+      shift
+      while [[ $# -gt 0 && ! "$1" =~ ^- ]]; do
+        BOUNDARIES_LIST+=("$1")
+        shift
+      done
       ;;
     -h|--help)
       usage
@@ -124,6 +134,10 @@ fi
 
 if [[ -n "$LOGGER" ]]; then
   PYTHON_CMD+=(--logger "$LOGGER")
+fi
+
+if [[ -n "$BOUNDARIES_LIST" ]]; then
+  PYTHON_CMD+=(--boundaries "${BOUNDARIES_LIST[@]}")
 fi
 
 # 3. Execute the array

--- a/projects/EarthNow/bin/plotall.py
+++ b/projects/EarthNow/bin/plotall.py
@@ -154,6 +154,7 @@ def parse_args():
     # -------------------------------------------------------------------------
     # Map features
     # -------------------------------------------------------------------------
+    # Left these args still so you can specify if you need
     parser.add_argument(
         "--boundaries",
         nargs="+",
@@ -284,6 +285,7 @@ def return_valid_directory(reader, args):
 # -----------------------------------------------------------------------------
 
 
+# Note that these override the style arguments
 def build_style(args):
     style = STYLES[args.style]()
 
@@ -291,6 +293,9 @@ def build_style(args):
         style.ocean_color = args.ocean_color
     if args.land_color:
         style.land_color = args.land_color
+
+    if args.boundaries:
+        style.boundaries = args.boundaries
 
     if args.boundaries_color:
         style.coastline_color = args.boundaries_color
@@ -327,7 +332,6 @@ def plot_single_pdate(pdate, args, style, map_config):
     plotter = WxMapPlotter(map_config, resolution=local_args.resolution, style=style)
 
     fig, ax = plotter.create_basemap(
-        boundaries=local_args.boundaries or [],
         feature_resolution=local_args.feature_resolution,
     )
 

--- a/projects/EarthNow/src/earthnow/paths.py
+++ b/projects/EarthNow/src/earthnow/paths.py
@@ -21,8 +21,10 @@ load_dotenv(CONFIG_DIR / ".env")
 def env_check(name: str, default: str | Path) -> str:
     return str(os.environ.get(name, default))
 
+
 def env_path(name: str, default: str | Path) -> Path:
     return Path(env_check(name, default))
+
 
 # ---------------------------------------------------------------------------
 # DATA URIS
@@ -62,6 +64,10 @@ _GMAO_OPS = env_path(
 )
 _CITIES_DIR = env_path("EARTHNOW_CITIES_DIR", "/home/wputman/IDL_BASE/CITIES")
 
+SHAPEFILES_PATH = env_path(
+    "SHAPEFILES_PATH", "/discover/swdev/gmao-tools/Visualization/shapefiles"
+)
+
 # ---------------------------------------------------------------------------
 # Derived constants
 # ---------------------------------------------------------------------------
@@ -84,6 +90,21 @@ DEFAULT_GENCAST_EXP_PATH = env_path(
     "EARTHNOW_DEFAULT_GENCAST_EXP_PATH", _OSSE2_ROOT / "GenCast_FP"
 )
 DEFAULT_GEOS_FP_BASE = env_path("EARTHNOW_DEFAULT_GEOS_FP_BASE", _GMAO_OPS)
+
+COUNTRY_BORDERS = env_path(
+    "COUNTRY_BORDERS",
+    SHAPEFILES_PATH / "state_dep_files" / "data" / "DoS_LSIB_v11_4_24Feb2025.shp",
+)
+
+STATE_BORDERS_5M = env_path(
+    "COUNTRY_BORDERS",
+    SHAPEFILES_PATH / "US_census_files" / "cb_2018_us_state_5m.shp",
+)
+
+COUNTY_BORDERS_5M = env_path(
+    "COUNTRY_BORDERS",
+    SHAPEFILES_PATH / "US_census_files" / "cb_2018_us_county_5m.shp",
+)
 
 # ---------------------------------------------------------------------------
 # Helper functions

--- a/projects/EarthNow/src/earthnow/wxmaps_config.py
+++ b/projects/EarthNow/src/earthnow/wxmaps_config.py
@@ -4,7 +4,7 @@ Defines standard projections, extents, and map parameters for weather visualizat
 with support for HD, 4K, and 8K resolutions at 16:9 aspect ratio
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Tuple, Optional, List, Dict, Any
 import cartopy.crs as ccrs
 import numpy as np
@@ -92,7 +92,7 @@ class StyleConfig:
     nws_custom_status: Optional[str] = None  # Single status: 'W', 'A', 'Y', 'S'
     nws_severe_only: bool = False  # Show only tornado and severe thunderstorm warnings
 
-    # Boundary styles
+    boundaries: list[str] = field(default_factory=list)  # Defaults to empty I think
     coastline_color: str = "#333333"
     coastline_width: float = 1.0
     coastline_alpha: float = 1.0

--- a/projects/EarthNow/src/earthnow/wxmaps_plotting.py
+++ b/projects/EarthNow/src/earthnow/wxmaps_plotting.py
@@ -209,7 +209,7 @@ class WxMapPlotter:
                 print("  Adding US State dept country borders")
                 self.ax.add_feature(countries_feature)
 
-            except:
+            except Exception:
                 print("  Adding Cartopy country borders")
                 self.ax.add_feature(
                     cfeature.BORDERS.with_scale(feature_resolution),
@@ -241,7 +241,7 @@ class WxMapPlotter:
                 print("  Adding US Census state borders")
                 self.ax.add_feature(states_feature)
 
-            except:
+            except Exception:
                 print("  Adding Cartopy state borders")
                 self.ax.add_feature(
                     cfeature.STATES.with_scale(feature_resolution),
@@ -273,7 +273,7 @@ class WxMapPlotter:
                 )
                 self.ax.add_feature(counties_feature)
 
-            except:
+            except Exception:
                 print("Warning: Could not load county boundaries")
 
         if "rivers" in boundaries:
@@ -941,7 +941,7 @@ class WxMapPlotter:
         valid_time : datetime
             Valid time for warnings
         """
-        # turn of nws warnings for "global"
+        # turn off nws warnings for "global"
         if not self.style.show_nws_warnings or self.config.name == "global":
             return
 

--- a/projects/EarthNow/src/earthnow/wxmaps_plotting.py
+++ b/projects/EarthNow/src/earthnow/wxmaps_plotting.py
@@ -183,27 +183,72 @@ class WxMapPlotter:
                 zorder=6,
             )
 
+        # US gov compliant shape files
+        shapefiles_path = "/discover/nobackup/hzafar/boundary_files/"
         if "countries" in boundaries:
-            print("  Adding Cartopy country borders")
-            self.ax.add_feature(
-                cfeature.BORDERS.with_scale(feature_resolution),
-                linewidth=self.style.country_width,
-                edgecolor=self.style.country_color,
-                alpha=self.style.country_alpha,
-                facecolor="none",
-                zorder=5,
-            )
+            try:
+                from cartopy.io.shapereader import Reader
+                from cartopy.feature import ShapelyFeature
+
+                countries_path = (
+                    shapefiles_path
+                    + "state_dep_files/data/DoS_LSIB_v11_4_24Feb2025.shp"
+                )
+                countries_feature = ShapelyFeature(
+                    Reader(countries_path).geometries(),
+                    crs=ccrs.PlateCarree(),
+                    linewidth=self.style.country_width,
+                    edgecolor=self.style.country_color,
+                    alpha=self.style.country_alpha,
+                    facecolor="none",
+                    zorder=5,
+                )
+
+                print("  Adding US State dept country borders")
+                self.ax.add_feature(countries_feature)
+
+            except:
+                print("  Adding Cartopy country borders")
+                self.ax.add_feature(
+                    cfeature.BORDERS.with_scale(feature_resolution),
+                    linewidth=self.style.country_width,
+                    edgecolor=self.style.country_color,
+                    alpha=self.style.country_alpha,
+                    facecolor="none",
+                    zorder=5,
+                )
 
         if "states" in boundaries:
-            print("  Adding Cartopy state borders")
-            self.ax.add_feature(
-                cfeature.STATES.with_scale(feature_resolution),
-                linewidth=self.style.state_width,
-                edgecolor=self.style.state_color,
-                alpha=self.style.state_alpha,
-                facecolor="none",
-                zorder=5,
-            )
+            try:
+                from cartopy.io.shapereader import Reader
+                from cartopy.feature import ShapelyFeature
+
+                states_path = (
+                    shapefiles_path + "US_census_files/cb_2018_us_state_5m.shp"
+                )
+                states_feature = ShapelyFeature(
+                    Reader(states_path).geometries(),
+                    crs=ccrs.PlateCarree(),
+                    linewidth=self.style.state_width,
+                    edgecolor=self.style.state_color,
+                    alpha=self.style.state_alpha,
+                    facecolor="none",
+                    zorder=5,
+                )
+
+                print("  Adding US Census state borders")
+                self.ax.add_feature(states_feature)
+
+            except:
+                print("  Adding Cartopy state borders")
+                self.ax.add_feature(
+                    cfeature.STATES.with_scale(feature_resolution),
+                    linewidth=self.style.state_width,
+                    edgecolor=self.style.state_color,
+                    alpha=self.style.state_alpha,
+                    facecolor="none",
+                    zorder=5,
+                )
 
         if "counties" in boundaries:
             # Counties require additional Natural Earth data
@@ -211,10 +256,21 @@ class WxMapPlotter:
                 from cartopy.io.shapereader import Reader
                 from cartopy.feature import ShapelyFeature
 
-                # This would need the counties shapefile
-                print(
-                    "Warning: County boundaries require additional Natural Earth data"
+                print("  Adding US Census counties")
+                counties_path = (
+                    shapefiles_path + "US_census_files/cb_2018_us_county_5m.shp"
                 )
+                counties_feature = ShapelyFeature(
+                    Reader(counties_path).geometries(),
+                    crs=ccrs.PlateCarree(),
+                    linewidth=self.style.county_width,
+                    edgecolor=self.style.county_color,
+                    alpha=self.style.county_alpha,
+                    facecolor="none",
+                    zorder=5,
+                )
+                self.ax.add_feature(counties_feature)
+
             except:
                 print("Warning: Could not load county boundaries")
 

--- a/projects/EarthNow/src/earthnow/wxmaps_plotting.py
+++ b/projects/EarthNow/src/earthnow/wxmaps_plotting.py
@@ -27,7 +27,8 @@ from earthnow.wxmaps_config import (
     ResolutionConfig,
     StyleConfig,
 )
-from earthnow import paths
+from earthnow.paths import COUNTRY_BORDERS, STATE_BORDERS_5M, COUNTY_BORDERS_5M
+
 import logging
 
 logger = logging.getLogger(__name__)
@@ -185,19 +186,14 @@ class WxMapPlotter:
                 zorder=6,
             )
 
-        # US gov compliant shape files
-        shapefiles_path = "/discover/nobackup/hzafar/boundary_files/"
+        # Using US gov compliant shape files
         if "countries" in boundaries:
             try:
                 from cartopy.io.shapereader import Reader
                 from cartopy.feature import ShapelyFeature
 
-                countries_path = (
-                    shapefiles_path
-                    + "state_dep_files/data/DoS_LSIB_v11_4_24Feb2025.shp"
-                )
                 countries_feature = ShapelyFeature(
-                    Reader(countries_path).geometries(),
+                    Reader(COUNTRY_BORDERS).geometries(),
                     crs=ccrs.PlateCarree(),
                     linewidth=self.style.country_width,
                     edgecolor=self.style.country_color,
@@ -209,6 +205,7 @@ class WxMapPlotter:
                 print("  Adding US State dept country borders")
                 self.ax.add_feature(countries_feature)
 
+            # Fall back to cartopy if fails
             except Exception:
                 print("  Adding Cartopy country borders")
                 self.ax.add_feature(
@@ -229,7 +226,7 @@ class WxMapPlotter:
                     shapefiles_path + "US_census_files/cb_2018_us_state_5m.shp"
                 )
                 states_feature = ShapelyFeature(
-                    Reader(states_path).geometries(),
+                    Reader(STATE_BORDERS_5M).geometries(),
                     crs=ccrs.PlateCarree(),
                     linewidth=self.style.state_width,
                     edgecolor=self.style.state_color,
@@ -241,6 +238,7 @@ class WxMapPlotter:
                 print("  Adding US Census state borders")
                 self.ax.add_feature(states_feature)
 
+            # Fall back to Cartopy if failing
             except Exception:
                 print("  Adding Cartopy state borders")
                 self.ax.add_feature(
@@ -259,11 +257,8 @@ class WxMapPlotter:
                 from cartopy.feature import ShapelyFeature
 
                 print("  Adding US Census counties")
-                counties_path = (
-                    shapefiles_path + "US_census_files/cb_2018_us_county_5m.shp"
-                )
                 counties_feature = ShapelyFeature(
-                    Reader(counties_path).geometries(),
+                    Reader(COUNTY_BORDERS_5M).geometries(),
                     crs=ccrs.PlateCarree(),
                     linewidth=self.style.county_width,
                     edgecolor=self.style.county_color,

--- a/projects/EarthNow/src/earthnow/wxmaps_plotting.py
+++ b/projects/EarthNow/src/earthnow/wxmaps_plotting.py
@@ -101,7 +101,7 @@ class WxMapPlotter:
         )
 
     def create_basemap(
-        self, feature_resolution: str = "50m"
+        self, boundaries: Optional[list[str]] = None, feature_resolution: str = "50m"
     ) -> Tuple[plt.Figure, plt.Axes]:
         """Create base map with specified boundaries"""
 
@@ -110,7 +110,9 @@ class WxMapPlotter:
             boundaries = []
         else:
             boundaries = self.style.boundaries
-        logger.info(boundaries)
+        logger.debug(
+            f"Boundaries plotting: {boundaries}\nNote that boundaries defined in style may be overridden by runtime args or optional function call"
+        )
 
         # Create figure with high DPI
         self.fig = plt.figure(figsize=self.figsize, dpi=self.dpi)

--- a/projects/EarthNow/src/earthnow/wxmaps_plotting.py
+++ b/projects/EarthNow/src/earthnow/wxmaps_plotting.py
@@ -28,6 +28,9 @@ from earthnow.wxmaps_config import (
     StyleConfig,
 )
 from earthnow import paths
+import logging
+
+logger = logging.getLogger(__name__)
 
 # =============================================================================
 # Boundary draw order (bottom → top)
@@ -98,12 +101,16 @@ class WxMapPlotter:
         )
 
     def create_basemap(
-        self, boundaries: Optional[List[str]] = None, feature_resolution: str = "50m"
+        self, feature_resolution: str = "50m"
     ) -> Tuple[plt.Figure, plt.Axes]:
         """Create base map with specified boundaries"""
 
-        if boundaries is None:
-            boundaries = ["coastlines", "countries", "states"]
+        # Turn off boundaries for all global views
+        if self.config.name == "global":
+            boundaries = []
+        else:
+            boundaries = self.style.boundaries
+        logger.info(boundaries)
 
         # Create figure with high DPI
         self.fig = plt.figure(figsize=self.figsize, dpi=self.dpi)
@@ -876,7 +883,8 @@ class WxMapPlotter:
         valid_time : datetime
             Valid time for warnings
         """
-        if not self.style.show_nws_warnings:
+        # turn of nws warnings for "global"
+        if not self.style.show_nws_warnings or self.config.name == "global":
             return
 
         try:


### PR DESCRIPTION
Configure which boundaries to include in either the plotall.py call or the style itself. Remove boundaries in global views. (Note: I checked all the EarthNow products and none include boundary shapefiles for the global extents, although some do include the built-in "map service" boundaries on the client side.)
Add shapefile imagery sources for counties, option for countries and states to use US census/state dept. ~~The file location of these shapefiles is temporarily in my $NOBACKUP directory until we can find a better suited place for it.~~