### PR TITLE
Update from Hannah's variable registry 

### DIFF
--- a/projects/EarthNow/pyproject.toml
+++ b/projects/EarthNow/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "geopandas",
   "python_dotenv",
   "wxvis",
+  "pyyaml",
 ]
 
 

--- a/projects/EarthNow/src/earthnow/data_readers/conus2kmfc.py
+++ b/projects/EarthNow/src/earthnow/data_readers/conus2kmfc.py
@@ -1,11 +1,11 @@
 from types import SimpleNamespace
 from .dataservice import DataService
 from .registry import register
-from .variables import return_fullname
+from .variables import VARIABLE_REGISTRY
 
 CONUS2KMFC_URI = "/discover/nobackup/projects/gmao/osse2/HWT/CONUS02KM/Feature-c2160_L137/forecasts/CYCLED_REPLAY_P10800_C21600_T21600_%%Y%%m%%d_%%Hz/GEOS.$collection.%Y%m%d_%H%Mz.nc4"
 
-CONUS2KMFC_VARS = return_fullname(
+CONUS2KMFC_VARS = VARIABLE_REGISTRY.resolve_many(
     {
         "VORT500": "inst1_2d_asm_Nx",
         "H500": "inst1_2d_asm_Nx",

--- a/projects/EarthNow/src/earthnow/data_readers/conus2kmfc_lcc.py
+++ b/projects/EarthNow/src/earthnow/data_readers/conus2kmfc_lcc.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 from .dataservice import DataService
 from .registry import register
-from .variables import return_fullname
+from .variables import VARIABLE_REGISTRY
 
 CONUS2KMFC_LCC_URI = "/discover/nobackup/projects/gmao/osse2/HWT/CONUS02KM/Feature-c2160_L137/forecasts/CYCLED_REPLAY_P10800_C21600_T21600_%%Y%%m%%d_%%Hz/GEOS.$collection.%Y%m%d_%H%Mz.nc4"
 
@@ -9,7 +9,7 @@ CONUS2KMFC_LCC_COORDS = (
     "/discover/nobackup/projects/gmao/osse2/stage/BCS_FILES/lambert_grid.nc4"
 )
 
-CONUS2KMFC_LCC_VARS = return_fullname(
+CONUS2KMFC_LCC_VARS = VARIABLE_REGISTRY.resolve_many(
     {
         "VORT500": "hwt_30mn_slv_LCC",
         "H500": "hwt_30mn_slv_LCC",

--- a/projects/EarthNow/src/earthnow/data_readers/conus2kmrp.py
+++ b/projects/EarthNow/src/earthnow/data_readers/conus2kmrp.py
@@ -1,11 +1,11 @@
 from types import SimpleNamespace
 from .dataservice import DataService
 from .registry import register
-from .variables import return_fullname
+from .variables import VARIABLE_REGISTRY
 
 CONUS2KMRP_URI = "/discover/nobackup/projects/gmao/osse2/HWT/CONUS02KM/Feature-c2160_L137/holding/$collection/%Y%m/Feature-c2160_L137.$collection.%Y%m%d_%H%Mz.nc4"
 
-CONUS2KMRP_VARS = return_fullname(
+CONUS2KMRP_VARS = VARIABLE_REGISTRY.resolve_many(
     {
         "VORT500": "inst1_2d_asm_Nx",
         "H500": "inst1_2d_asm_Nx",

--- a/projects/EarthNow/src/earthnow/data_readers/conus2kmrp_lcc.py
+++ b/projects/EarthNow/src/earthnow/data_readers/conus2kmrp_lcc.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 from .dataservice import DataService
 from .registry import register
-from .variables import return_fullname
+from .variables import VARIABLE_REGISTRY
 
 CONUS2KMRP_LCC_URI = "/discover/nobackup/projects/gmao/osse2/HWT/CONUS02KM/Feature-c2160_L137/holding/$collection/%Y%m/Feature-c2160_L137.$collection.%Y%m%d_%H%Mz.nc4"
 
@@ -9,7 +9,7 @@ CONUS2KMRP_LCC_COORDS = (
     "/discover/nobackup/projects/gmao/osse2/stage/BCS_FILES/lambert_grid.nc4"
 )
 
-CONUS2KMRP_LCC_VARS = return_fullname(
+CONUS2KMRP_LCC_VARS = VARIABLE_REGISTRY.resolve_many(
     {
         "VORT500": "hwt_30mn_slv_LCC",
         "H500": "hwt_30mn_slv_LCC",

--- a/projects/EarthNow/src/earthnow/data_readers/variables.py
+++ b/projects/EarthNow/src/earthnow/data_readers/variables.py
@@ -1,123 +1,62 @@
+from pathlib import Path
 from typing import Optional
-from dataclasses import dataclass, field, fields
 
-"""
-TEMPLATE TO ADD PRODUCTS TO THE DICTIONARY BELOW, THEY WILL BE AUTOMATICALLY ADDED TO VARIABLE_REGISTRY
-    "ALIAS": {
-        "alias": "ALIAS", # The alias should match that used in inst1_2d_asm_Nx
-        "description": "DESCRIPTION",  # Long name description
-        "collection": {
-            "inst1_2d_asm_Nx": "VARIABLE_NAME",
-            "hwt_15mn_slv_LCC": "VARIABLE_NAME",
-            "hwt_30mn_slv_LCC": "VARIABLE_NAME",
-        },
-"""
-PRODUCTS_DICTIONARY = {
-    "CAPE": {
-        "alias": "CAPE",
-        "description": "Convective Available Potential Energy (J/kg)",
-        "collection": {
-            "inst1_2d_asm_Nx": "CAPE",
-            "hwt_15mn_slv_LCC": "CAPE",
-            "hwt_30mn_slv_LCC": "CAPE",
-        },
-    },
-    "DBZ_MAX": {
-        "alias": "DBZ_MAX",
-        "description": "Maximum Composite Radar Reflectivity",
-        "collection": {
-            "inst1_2d_asm_Nx": "DBZ_MAX",
-            "hwt_15mn_slv_LCC": "REFC",
-            "hwt_30mn_slv_LCC": "REFC",
-        },
-    },
-    "H500": {
-        "alias": "H500",
-        "description": "Height at 500 hPa (m)",
-        "collection": {
-            "inst1_2d_asm_Nx": "H500",
-            "hwt_15mn_slv_LCC": "H500",
-            "hwt_30mn_slv_LCC": "H500",
-        },
-    },
-    "HGT_SFC": {
-        "alias": "HGT_SFC",
-        "description": "",
-        "collection": {
-            "hwt_15mn_slv_LCC": "HGT_SFC",
-            "hwt_30mn_slv_LCC": "HGT_SFC",
-        },
-    },
-    "ICE": {
-        "alias": "ICE",
-        "description": "",
-        "collection": {
-            "inst1_2d_asm_Nx": "ICE",
-            "hwt_15mn_slv_LCC": "ICE",
-            "hwt_30mn_slv_LCC": "ICE",
-        },
-    },
-    "RAIN": {
-        "alias": "RAIN",
-        "description": "",
-        "collection": {
-            "inst1_2d_asm_Nx": "RAIN",
-            "hwt_15mn_slv_LCC": "RAIN",
-            "hwt_30mn_slv_LCC": "RAIN",
-        },
-    },
-    "SNOW": {
-        "alias": "SNOW",
-        "description": "",
-        "collection": {
-            "inst1_2d_asm_Nx": "SNOW",
-            "hwt_15mn_slv_LCC": "SNOW",
-            "hwt_30mn_slv_LCC": "SNOW",
-        },
-    },
-    "T2M": {
-        "alias": "T2M",
-        "description": "2 Meter Temperature",
-        "collection": {
-            "inst1_2d_asm_Nx": "TMP",
-            "hwt_15mn_slv_LCC": "TMP_2M",
-            "hwt_30mn_slv_LCC": "TMP_2M",
-        },
-    },
-    "UH25": {
-        "alias": "UH25",
-        "description": "Updraft Helicity 2-5 KM (m2 s-2)",
-        "collection": {
-            "inst1_2d_asm_Nx": "UH25",
-            "hwt_15mn_slv_LCC": "UPHL_2-KM",
-            "hwt_30mn_slv_LCC": "UPHL_2-KM",
-        },
-    },
-    "VORT500": {
-        "alias": "VORT500",
-        "description": "500 mb Relative Vorticity",
-        "collection": {
-            "inst1_2d_asm_Nx": "VORT500",
-            "hwt_15mn_slv_LCC": "VORT500",
-            "hwt_30mn_slv_LCC": "VORT500",
-        },
-    },
-}
+import yaml
+from dataclasses import dataclass, field
 
-VARIABLE_REGISTRY = {}
+VARIABLES_YAML = Path(__file__).parent / "variables.yaml"
+
+
+class VariableRegistry(dict):
+    """Dict of alias -> ValidVariable, with lookups."""
+
+    def register(self, variable: "ValidVariable") -> None:
+        if variable.alias in self:
+            raise ValueError(f"Error: The alias '{variable.alias}' is already registered")
+        self[variable.alias] = variable
+
+    @property
+    def aliases(self) -> list[str]:
+        return list(self.keys())
+
+    @property
+    def collections(self) -> list[str]:
+        names = {name for var in self.values() for name in var.collection.collection}
+        return sorted(names)
+
+    def collection_aliases(self, collection_name: str) -> list[str]:
+        """All aliases that define a variable name for the given collection."""
+        return [
+            alias
+            for alias, var in self.items()
+            if collection_name in var.collection.collection
+        ]
+
+    def resolve(self, alias: str, collection_name: str) -> str:
+        """Returns "<varname>.<collection_name>" for alias, raising if either is invalid."""
+        if alias not in self:
+            raise KeyError(f"'{alias}' is not a registered alias")
+        fullname = self[alias].collection.return_fullname(collection_name)
+        if fullname is None:
+            raise ValueError(
+                f"'{alias}' has no variable registered for collection '{collection_name}'"
+            )
+        return fullname
+
+
+VARIABLE_REGISTRY = VariableRegistry()
 
 
 # Define a data class for the collections
 @dataclass(frozen=True)
 class CollectionVariable:
-    # Each colleciton is optional since not all vars have all collections
-    inst1_2d_asm_Nx: Optional[str] = None
-    hwt_15mn_slv_LCC: Optional[str] = None
-    hwt_30mn_slv_LCC: Optional[str] = None
+    # Maps collection name -> variable name within that collection.
+    # Not all vars have all collections, and new collections require no code changes.
+    collection: dict[str, str] = field(default_factory=dict)
 
     def return_fullname(self, collection_name: str) -> Optional[str]:
         """Returns the formatted string for a specific collection name if it exists."""
-        value = getattr(self, collection_name, None)
+        value = self.collection.get(collection_name)
         if value:
             return f"{value}.{collection_name}"
         return None
@@ -128,25 +67,21 @@ class CollectionVariable:
 class ValidVariable:
     alias: str
     description: str
-    collection: list[CollectionVariable] = field(default_factory=CollectionVariable)
-
-    def __post_init__(self):
-        # Check for duplicates, every alias must be unique
-        if self.alias in VARIABLE_REGISTRY:
-            raise ValueError(f"Error: The alias '{self.alias}' is already registered")
-        VARIABLE_REGISTRY[self.alias] = self
+    collection: CollectionVariable = field(default_factory=CollectionVariable)
 
 
 def return_fullname(input_dict: dict):
     return {
-        key: VARIABLE_REGISTRY[key].collection.return_fullname(value)
-        for key, value in input_dict.items()
+        key: VARIABLE_REGISTRY.resolve(key, value) for key, value in input_dict.items()
     }
 
 
-# Add dictionaries to the class registry
-for key, data in PRODUCTS_DICTIONARY.items():
-    coll_var = CollectionVariable(**data["collection"])
-    ValidVariable(
-        alias=data["alias"], description=data["description"], collection=coll_var
+# Load variable definitions and register them
+with open(VARIABLES_YAML) as f:
+    PRODUCTS_DICTIONARY = yaml.safe_load(f)
+
+for alias, data in PRODUCTS_DICTIONARY.items():
+    coll_var = CollectionVariable(collection=data["collection"])
+    VARIABLE_REGISTRY.register(
+        ValidVariable(alias=alias, description=data["description"], collection=coll_var)
     )

--- a/projects/EarthNow/src/earthnow/data_readers/variables.py
+++ b/projects/EarthNow/src/earthnow/data_readers/variables.py
@@ -43,8 +43,12 @@ class VariableRegistry(dict):
             )
         return fullname
 
-
-VARIABLE_REGISTRY = VariableRegistry()
+    def resolve_many(self, alias_to_collection: dict[str, str]) -> dict[str, str]:
+        """Batch form of resolve(): {alias: collection_name} -> {alias: fullname}."""
+        return {
+            alias: self.resolve(alias, collection_name)
+            for alias, collection_name in alias_to_collection.items()
+        }
 
 
 # Define a data class for the collections
@@ -70,18 +74,18 @@ class ValidVariable:
     collection: CollectionVariable = field(default_factory=CollectionVariable)
 
 
-def return_fullname(input_dict: dict):
-    return {
-        key: VARIABLE_REGISTRY.resolve(key, value) for key, value in input_dict.items()
-    }
+def build_registry(yaml_path: Path) -> VariableRegistry:
+    """Loads variable definitions from yaml_path and registers them."""
+    with open(yaml_path) as f:
+        products = yaml.safe_load(f)
+
+    registry = VariableRegistry()
+    for alias, data in products.items():
+        collection = CollectionVariable(collection=data["collection"])
+        registry.register(
+            ValidVariable(alias=alias, description=data["description"], collection=collection)
+        )
+    return registry
 
 
-# Load variable definitions and register them
-with open(VARIABLES_YAML) as f:
-    PRODUCTS_DICTIONARY = yaml.safe_load(f)
-
-for alias, data in PRODUCTS_DICTIONARY.items():
-    coll_var = CollectionVariable(collection=data["collection"])
-    VARIABLE_REGISTRY.register(
-        ValidVariable(alias=alias, description=data["description"], collection=coll_var)
-    )
+VARIABLE_REGISTRY = build_registry(VARIABLES_YAML)

--- a/projects/EarthNow/src/earthnow/data_readers/variables.yaml
+++ b/projects/EarthNow/src/earthnow/data_readers/variables.yaml
@@ -1,0 +1,82 @@
+# Registry of valid variables and their per-collection names.
+#
+# TEMPLATE TO ADD A VARIABLE:
+# ALIAS:
+#   description: "DESCRIPTION"  # Long name description
+#   collection:
+#     inst1_2d_asm_Nx: VARIABLE_NAME
+#     hwt_15mn_slv_LCC: VARIABLE_NAME
+#     hwt_30mn_slv_LCC: VARIABLE_NAME
+#
+# The top-level key is the alias (must match that used across collections).
+# A variable does not need an entry for every collection, and new collection
+# names can be added freely -- no code changes required.
+
+CAPE:
+  description: "Convective Available Potential Energy (J/kg)"
+  collection:
+    inst1_2d_asm_Nx: CAPE
+    hwt_15mn_slv_LCC: CAPE
+    hwt_30mn_slv_LCC: CAPE
+
+DBZ_MAX:
+  description: "Maximum Composite Radar Reflectivity"
+  collection:
+    inst1_2d_asm_Nx: DBZ_MAX
+    hwt_15mn_slv_LCC: REFC
+    hwt_30mn_slv_LCC: REFC
+
+H500:
+  description: "Height at 500 hPa (m)"
+  collection:
+    inst1_2d_asm_Nx: H500
+    hwt_15mn_slv_LCC: H500
+    hwt_30mn_slv_LCC: H500
+
+HGT_SFC:
+  description: ""
+  collection:
+    hwt_15mn_slv_LCC: HGT_SFC
+    hwt_30mn_slv_LCC: HGT_SFC
+
+ICE:
+  description: ""
+  collection:
+    inst1_2d_asm_Nx: ICE
+    hwt_15mn_slv_LCC: ICE
+    hwt_30mn_slv_LCC: ICE
+
+RAIN:
+  description: ""
+  collection:
+    inst1_2d_asm_Nx: RAIN
+    hwt_15mn_slv_LCC: RAIN
+    hwt_30mn_slv_LCC: RAIN
+
+SNOW:
+  description: ""
+  collection:
+    inst1_2d_asm_Nx: SNOW
+    hwt_15mn_slv_LCC: SNOW
+    hwt_30mn_slv_LCC: SNOW
+
+T2M:
+  description: "2 Meter Temperature"
+  collection:
+    inst1_2d_asm_Nx: TMP
+    hwt_15mn_slv_LCC: TMP_2M
+    hwt_30mn_slv_LCC: TMP_2M
+
+UH25:
+  description: "Updraft Helicity 2-5 KM (m2 s-2)"
+  collection:
+    inst1_2d_asm_Nx: UH25
+    hwt_15mn_slv_LCC: UPHL_2-KM
+    hwt_30mn_slv_LCC: UPHL_2-KM
+
+VORT500:
+  description: "500 mb Relative Vorticity"
+  collection:
+    inst1_2d_asm_Nx: VORT500
+    hwt_15mn_slv_LCC: VORT500
+    hwt_30mn_slv_LCC: VORT500


### PR DESCRIPTION
uses yaml and includes lookups for available aliases/collections

Also adds more verbose warning for errors of aliases and/or collections when return_fullname is called

and makes CollectionVariable more (?) robust (less need to update variables.py, just variables.yaml, collections names are used from what's added to the yaml file) 

