### PR TITLE
Update uv lock to fix bug

### DIFF
--- a/projects/EarthNow/uv.lock
+++ b/projects/EarthNow/uv.lock
@@ -2075,7 +2075,7 @@ wheels = [
 [[package]]
 name = "wxvis"
 version = "0.1.0"
-source = { git = "https://github.com/GEOS-ESM/tools-team-misc.git?subdirectory=projects%2FWxVis&branch=main#2dc7e1ce44270fcfae7b47dc12951c5eabb23a59" }
+source = { git = "https://github.com/GEOS-ESM/tools-team-misc.git?subdirectory=projects%2FWxVis&branch=main#d1dd1a41a420fc282bb8ada7c09f08c002ceafc2" }
 
 [[package]]
 name = "xarray"


### PR DESCRIPTION
Uv lock has to be updated via `uv lock --upgrade-package wxvis` every time we add to wxvis for changes to propogate.